### PR TITLE
Add TransportationIcon component

### DIFF
--- a/packages/mobile/src/components/TransportationIcon.tsx
+++ b/packages/mobile/src/components/TransportationIcon.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Image, ImageStyle, StyleProp } from 'react-native';
+
+export type TransportationType = 'car' | 'van' | 'bus' | 'bike';
+
+type Props = {
+  type: TransportationType;
+  size?: number;
+  style?: StyleProp<ImageStyle>;
+  accessibilityLabel?: string;
+};
+
+const ICONS: Record<TransportationType, any> = {
+  car: require('../assets/images/transport_car.png'),
+  van: require('../assets/images/transport_van.png'),
+  bus: require('../assets/images/transport_bus.png'),
+  bike: require('../assets/images/transport_bike.png'),
+};
+
+export default function TransportationIcon({
+  type,
+  size = 24,
+  style,
+  accessibilityLabel,
+}: Props) {
+  return (
+    <Image
+      source={ICONS[type]}
+      style={[{ width: size, height: size }, style]}
+      resizeMode="contain"
+      accessibilityRole="image"
+      accessibilityLabel={accessibilityLabel ?? `${type} icon`}
+    />
+  );
+}


### PR DESCRIPTION
### Summary
created a reusable TransportationIcon component based on the finalized Figma designs

### What I did
- added a new `TransportationIcon` component
- mapped transportation types (car, van, bus, bike) to their icons
- made the icon size configurable and easy to reuse across pages

### Files added / changed
- `packages/mobile/src/components/TransportationIcon.tsx`
- `packages/mobile/src/assets/images/transport_car.png`
- `packages/mobile/src/assets/images/transport_van.png`
- `packages/mobile/src/assets/images/transport_bus.png`
- `packages/mobile/src/assets/images/transport_bike.png`

### Screenshots
images based off the figma
<img width="433" height="300" alt="image" src="https://github.com/user-attachments/assets/0e07ec3d-6b89-4828-8d32-9d3b11282f60" />

